### PR TITLE
overload stringification

### DIFF
--- a/lib/Object/String.pm
+++ b/lib/Object/String.pm
@@ -13,6 +13,7 @@ use List::Util;
 
 use Moo;
 use namespace::clean;
+use overload 'nomethod' => sub { $_[0]->string };
 
 =head1 DESCRIPTION
 

--- a/t/String.t
+++ b/t/String.t
@@ -837,5 +837,8 @@ is(
     'transliterate "test" into "TEST"'
 );
 
+##########
+is str('test')->humanize . 'foo', 'Testfoo', 'overload stringification';
+
 done_testing;
 


### PR DESCRIPTION
This overloads stringification, so you can use an Object::String in an expression and it will automatically call string().

IOW, you should be able to do: "print str('test')" and it will work as you'd expect.

Added test for it.